### PR TITLE
Fix for array and string offset access syntax

### DIFF
--- a/format.php
+++ b/format.php
@@ -378,7 +378,7 @@ class qformat_giftmedia extends qformat_gift {
         } else if ($answertext == '') {
             $question->qtype = 'essay';
 
-        } else if ($answertext{0} == '#') {
+        } else if ($answertext[0] == '#') {
             $question->qtype = 'numerical';
 
         } else if (strpos($answertext, '~') !== false) {


### PR DESCRIPTION
Plugin don't work PHP 8.1

Fatal error: Array and string offset access syntax with curly braces is no longer supported in \question\format\giftmedia\format.php on line 381

